### PR TITLE
api: Reintroduce `getBug()` method

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -94,6 +94,12 @@ export default class BugzillaAPI {
     );
   }
 
+  public getBug(id: number | string): FilteredQuery<Bug> {
+    return this.searchBugs({
+      id,
+    })[0];
+  }
+
   public getBugs(ids: (number | string)[]): FilteredQuery<Bug> {
     return this.searchBugs({
       id: ids.join(","),


### PR DESCRIPTION
Please reintroduce method that was removed by a2200c2444bf8827850056245f4219b17734643f.

Since then the method was listed in [README](https://github.com/Mossop/bugzilla-ts/blob/main/README.md?plain=1#L33). IMHO it would be great to have such API call.