### PR TITLE
Add code coverage using `codecov`

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,6 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 5%

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Build test
+name: Build and Coverage
 
 on:
   push:
@@ -38,3 +38,7 @@ jobs:
 
       - name: Test
         run: npm test
+
+      - name: Codecov
+        if: ${{ matrix.node-version == '17.x' }}
+        uses: codecov/codecov-action@v2

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 /node_modules
+/coverage
 /dist
 /.vscode
+
 .*
 *.tsbuildinfo

--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,6 @@
 /.github
 /config
+/coverage
 /scripts
 /jest.config.js
 /tsconfig.*

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Bugzilla | [![Build](https://github.com/Mossop/bugzilla-ts/actions/workflows/build.yml/badge.svg)](https://github.com/Mossop/bugzilla-ts/actions/workflows/build.yml)
+# Bugzilla | [![npm version](https://badgen.net/npm/v/bugzilla)](https://www.npmjs.com/package/bugzilla) [![Build](https://github.com/Mossop/bugzilla-ts/actions/workflows/build.yml/badge.svg)](https://github.com/Mossop/bugzilla-ts/actions/workflows/build.yml)
 
 Typesafe access to [Bugzilla's REST API](https://bugzilla.readthedocs.io/en/latest/api/index.html).
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Bugzilla | [![npm version](https://badgen.net/npm/v/bugzilla)](https://www.npmjs.com/package/bugzilla) [![Build](https://github.com/Mossop/bugzilla-ts/actions/workflows/build.yml/badge.svg)](https://github.com/Mossop/bugzilla-ts/actions/workflows/build.yml)
+# Bugzilla | [![npm version](https://badgen.net/npm/v/bugzilla)](https://www.npmjs.com/package/bugzilla) [![Build](https://github.com/Mossop/bugzilla-ts/actions/workflows/build.yml/badge.svg)](https://github.com/Mossop/bugzilla-ts/actions/workflows/build.yml) [![codecov](https://codecov.io/gh/Mossop/bugzilla-ts/branch/main/graph/badge.svg)](https://codecov.io/gh/Mossop/bugzilla-ts)
 
 Typesafe access to [Bugzilla's REST API](https://bugzilla.readthedocs.io/en/latest/api/index.html).
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build": "tsc -b tsconfig.build.json",
     "lint": "eslint . && prettier --check .",
     "prettier": "prettier --write .",
-    "test": "jest",
+    "test": "jest --coverage",
     "prepack": "npm run build",
     "version": "node scripts/version.js",
     "postversion": "node scripts/post-version.js && git add CHANGELOG.md && git commit -m 'Update CHANGELOG.md'"


### PR DESCRIPTION
This PR also adds `npm` and `codecov` badges for better awareness of current version of package and current code coverage.

Fixes: #22

---

_NOTE: `bugzilla-ts` repository might needs to be registered at [codecov](https://about.codecov.io/)._