### PR TITLE
api: Fix typo in createComment() if check

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -188,7 +188,7 @@ export default class BugzillaAPI {
       content,
     );
 
-    if (!comment) {
+    if (!commentStatus) {
       throw new Error("Failed to create comment.");
     }
 

--- a/test/__snapshots__/integration.test.ts.snap
+++ b/test/__snapshots__/integration.test.ts.snap
@@ -527,7 +527,7 @@ Array [
       Object {
         "id": 448747,
         "name": "gsvelto@mozilla.com",
-        "real_name": "Gabriele Svelto [:gsvelto]",
+        "real_name": "Gabriele Svelto [:gsvelto] (pto)",
       },
       Object {
         "id": 684527,
@@ -607,7 +607,7 @@ Array [
       Object {
         "id": 533624,
         "name": "jrediger@mozilla.com",
-        "real_name": "Jan-Erik Rediger [:janerik]",
+        "real_name": "Jan-Erik Rediger [:janerik] (Away 2022-03-21 - 2022-04-04)",
       },
       Object {
         "id": 282978,


### PR DESCRIPTION
`comment` -> `commentStatus`