### PR TITLE
auth: Add support for Authorization header - Red Hat Bugzilla

### DIFF
--- a/src/link.ts
+++ b/src/link.ts
@@ -140,6 +140,8 @@ export class ApiKeyLink extends BugzillaLink {
         headers: {
           ...(config.headers ?? {}),
           "X-BUGZILLA-API-KEY": this.apiKey,
+          // Red Hat Bugzilla uses Authorization header - https://bugzilla.redhat.com/docs/en/html/api/core/v1/general.html#authentication
+          Authorization: `Bearer ${this.apiKey}`,
         },
       },
       validator,


### PR DESCRIPTION
Once again Red Hat Bugzilla differs from the original implementation.

Red Hat Bugzilla uses Authorization header as a way to send API Key - [docs](https://bugzilla.redhat.com/docs/en/html/api/core/v1/general.html#authentication).

I'm not 100% sure, but I think sending both headers should be fine, but I tested it only with the Red Hat Bugzilla API.