### PR TITLE
 Add support for Bugzilla attachments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,12 @@
 # [Next](https://github.com/Mossop/bugzilla-ts/compare/v2.2.0...main)
 
 - Run tests against a live Bugzilla instance.
+- Added `getAttachment`, `getBugAttachments`, `createAttachment` and `updateAttachment` API methods.
 
 # [2.2.0](https://github.com/Mossop/bugzilla-ts/compare/v2.1.0...v2.2.0)
 
 - Added `createBug` and `updateBug` API methods.
+- Added support for Authorization header for Red Hat Bugzilla
 
 # [2.1.0](https://github.com/Mossop/bugzilla-ts/compare/v2.0.0...v2.1.0)
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Return value is Comment object.
 ## Retrieving all comments of bug
 
 ```javascript
-// .getComments() accepts one parameter, ID of bug, as number
+// .getBugComments() accepts one parameter, ID of bug, as number
 let comments = await api.getBugComments(123456);
 ```
 
@@ -150,3 +150,49 @@ let response = await api.updateBug(123456, {
 ```
 
 Returned value is same as described in Bugzilla [docs](https://bugzilla.readthedocs.io/en/latest/api/core/v1/bug.html#update-bug).
+
+## Retrieving attachments by ID
+
+```javascript
+// .getAttachment() accepts one parameter, ID of attachment, as number
+let attachment = await api.getAttachment(123456);
+```
+
+Return value is Attachment object.
+
+## Retrieving all attachments of bug
+
+```javascript
+// .getBugsAttachments() accepts one parameter, ID of bug, as number
+let attachments = await api.getBugAttachments(123456);
+```
+
+Return value is array of Attachment objects.
+
+## Creating attachments
+
+```javascript
+let attachment = await api.createAttachment(123456, {
+  ids: [123456, 123457];
+  data:  Buffer.from('Attachment content');
+  file_name: "Attachment name";
+  summary: "Attachment summary";
+  content_type: "text/plain";
+  is_private?: false;
+});
+```
+
+Returned value is an array of IDs of the newly-created attachments.
+
+## Updating attachments
+
+Example of changing content type of attachment #123456:
+
+```javascript
+let response = await api.updateAttachment(123456, {
+  attachment_id: 123456,
+  content_type: "text/plain",
+});
+```
+
+Returned value is same as described in Bugzilla [docs](https://bugzilla.readthedocs.io/en/latest/api/core/v1/attachment.html#update-attachment).

--- a/itest/test/attachments.test.ts
+++ b/itest/test/attachments.test.ts
@@ -1,0 +1,284 @@
+import BugzillaAPI from "../../src";
+
+let api: BugzillaAPI;
+
+const bug = {
+  product: "TestProduct",
+  component: "TestComponent",
+  summary: "A test bug",
+  version: "unspecified",
+  description: "This is a test bug",
+  op_sys: "Mac OS",
+  platform: "Macintosh",
+  priority: "High",
+  severity: "major",
+};
+
+let bugs: number[] = [];
+
+beforeAll(async () => {
+  api = new BugzillaAPI(
+    "http://localhost:8088/bugzilla/",
+    "admin@nowhere.com",
+    "adminpass",
+  );
+
+  bugs.push(await api.createBug(bug));
+  bugs.push(await api.createBug(bug));
+
+  expect(bugs).toBeDefined();
+  expect(bugs.length).toEqual(2);
+});
+
+// Attachment 1
+test("Create simple attachment", async () => {
+  await expect(
+    api.createAttachment(bugs[0] as number, {
+      ids: [bugs[0] as number],
+      summary: "Test creation of simple attachment",
+      file_name: "image.png",
+      data: Buffer.from("This is not a image."),
+      content_type: "image/png",
+    }),
+  ).resolves.toEqual([1]);
+});
+
+// Attachment 2
+test("Create complex attachment", async () => {
+  await expect(
+    api.createAttachment(bugs[0] as number, {
+      ids: [bugs[0] as number],
+      summary: "Test creation of complex attachment",
+      file_name: "patch.patch",
+      data: Buffer.from("This is not a patch."),
+      content_type: "",
+      comment: "",
+      //   flags: [
+      //     {
+      //       name: "review",
+      //       status: "?",
+      //     },
+      //   ],
+      is_private: false,
+      is_patch: true,
+    }),
+  ).resolves.toEqual([2]);
+});
+
+// Attachments 3, 4
+test("Create attachment for multiple bugs at once", async () => {
+  await expect(
+    api.createAttachment(bugs[0] as number, {
+      ids: bugs,
+      summary: "Test creation of multiple attachments at once",
+      file_name: "image.png",
+      data: Buffer.from("This is not a image."),
+      content_type: "image/png",
+    }),
+  ).resolves.toEqual([3, 4]);
+});
+
+test("Get single attachment", async () => {
+  await expect(api.getAttachment(1)).resolves.toEqual({
+    bug_id: bugs[0],
+    content_type: "image/png",
+    creation_time: expect.anything(),
+    creator: "admin@nowhere.com",
+    data: Buffer.from("This is not a image."),
+    file_name: "image.png",
+    flags: [],
+    id: 1,
+    is_obsolete: false,
+    is_patch: false,
+    is_private: false,
+    last_change_time: expect.anything(),
+    size: 20,
+    summary: "Test creation of simple attachment",
+  });
+
+  await expect(api.getAttachment(2)).resolves.toEqual({
+    bug_id: bugs[0],
+    content_type: "text/plain",
+    creation_time: expect.anything(),
+    creator: "admin@nowhere.com",
+    data: Buffer.from("This is not a patch."),
+    file_name: "patch.patch",
+    flags: [],
+    id: 2,
+    is_obsolete: false,
+    is_patch: true,
+    is_private: false,
+    last_change_time: expect.anything(),
+    size: 20,
+    summary: "Test creation of complex attachment",
+  });
+});
+
+test("Get multiple attachments", async () => {
+  await expect(api.getBugAttachments(bugs[0] as number)).resolves.toEqual([
+    {
+      bug_id: bugs[0],
+      content_type: "image/png",
+      creation_time: expect.anything(),
+      creator: "admin@nowhere.com",
+      data: Buffer.from("This is not a image."),
+      file_name: "image.png",
+      flags: [],
+      id: 1,
+      is_obsolete: false,
+      is_patch: false,
+      is_private: false,
+      last_change_time: expect.anything(),
+      size: 20,
+      summary: "Test creation of simple attachment",
+    },
+    {
+      bug_id: bugs[0],
+      content_type: "text/plain",
+      creation_time: expect.anything(),
+      creator: "admin@nowhere.com",
+      data: Buffer.from("This is not a patch."),
+      file_name: "patch.patch",
+      flags: [],
+      id: 2,
+      is_obsolete: false,
+      is_patch: true,
+      is_private: false,
+      last_change_time: expect.anything(),
+      size: 20,
+      summary: "Test creation of complex attachment",
+    },
+    {
+      bug_id: bugs[0],
+      content_type: "image/png",
+      creation_time: expect.anything(),
+      creator: "admin@nowhere.com",
+      data: Buffer.from("This is not a image."),
+      file_name: "image.png",
+      flags: [],
+      id: 3,
+      is_obsolete: false,
+      is_patch: false,
+      is_private: false,
+      last_change_time: expect.anything(),
+      size: 20,
+      summary: "Test creation of multiple attachments at once",
+    },
+  ]);
+
+  await expect(api.getBugAttachments(bugs[1] as number)).resolves.toEqual([
+    {
+      bug_id: bugs[1],
+      content_type: "image/png",
+      creation_time: expect.anything(),
+      creator: "admin@nowhere.com",
+      data: Buffer.from("This is not a image."),
+      file_name: "image.png",
+      flags: [],
+      id: 4,
+      is_obsolete: false,
+      is_patch: false,
+      is_private: false,
+      last_change_time: expect.anything(),
+      size: 20,
+      summary: "Test creation of multiple attachments at once",
+    },
+  ]);
+});
+
+test(`Edit single attachment`, async () => {
+  await expect(
+    api.updateAttachment(1, {
+      ids: [1],
+      content_type: "text/plain",
+      comment: "new comment",
+      file_name: "new filename",
+      //   flags: [
+      //     {
+      //       id: 999,
+      //       name: "new-flag",
+      //       status: "?",
+      //       new: true,
+      //       requestee: "adminpass",
+      //     },
+      //   ],
+      is_obsolete: true,
+      is_patch: true,
+      // is_private: true,
+      summary: "new summary",
+    }),
+  ).resolves.toEqual([
+    {
+      changes: new Map([
+        ["file_name", { added: "new filename", removed: "image.png" }],
+        ["content_type", { added: "text/plain", removed: "image/png" }],
+        ["is_obsolete", { added: "1", removed: "0" }],
+        [
+          "summary",
+          {
+            added: "new summary",
+            removed: "Test creation of simple attachment",
+          },
+        ],
+        ["is_patch", { added: "1", removed: "0" }],
+      ]),
+      id: 1,
+      last_change_time: expect.anything(),
+    },
+  ]);
+});
+
+test("Edit multiple attachments", async () => {
+  await expect(
+    api.updateAttachment(2, {
+      ids: [2, 3],
+      content_type: "text/plain",
+      comment: "new comment",
+      file_name: "new filename",
+      // flags: [{ name: "new-flag", status: "?", new: true }],
+      is_obsolete: true,
+      is_patch: true,
+      // is_private: true,
+      summary: "new summary",
+    }),
+  ).resolves.toEqual([
+    {
+      changes: expect.anything(),
+      // new Map([
+      //   ["is_obsolete", { added: "1", removed: "0" }],
+      //   ["file_name", { added: "new filename", removed: "patch.patch" }],
+      //   [
+      //     "summary",
+      //     {
+      //       added: "new summary",
+      //       removed: "Test creation of complex attachment",
+      //     },
+      //   ],
+      // ]),
+      id: 2,
+      last_change_time: expect.anything(),
+    },
+    {
+      changes: expect.anything(),
+      // new Map([
+      //   ["file_name", { added: "new filename", removed: "image.png" }],
+      //   [
+      //     "summary",
+      //     {
+      //       added: "new summary",
+      //       removed: "Test creation of simple attachment",
+      //     },
+      //   ],
+      //   ["is_obsolete", { added: "1", removed: "0" }],
+      //   ["content_type", { added: "text/plain", removed: "image/png" }],
+      //   ["is_patch", { added: "1", removed: "0" }],
+      // ]);
+      id: 3,
+      last_change_time: expect.anything(),
+    },
+  ]);
+});
+
+afterAll(() => {
+  bugs = [];
+});

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,6 +16,7 @@ import {
   intString,
   map,
   double,
+  base64,
 } from "./validators";
 
 type int = number;
@@ -269,11 +270,6 @@ export interface CreateCommentContent {
   is_private: boolean;
 }
 
-export const CreateCommentContentSpec: ObjectSpec<CreateCommentContent> = {
-  comment: string,
-  is_private: boolean,
-};
-
 export interface CreatedComment {
   id: int;
 }
@@ -365,12 +361,12 @@ export interface UpdateBugContent {
   work_time?: double;
 }
 
-export interface UpdatedBugChanges {
+export interface Changes {
   added: string;
   removed: string;
 }
 
-const UpdatedBugChangesSpec: ObjectSpec<UpdatedBugChanges> = {
+const ChangesSpec: ObjectSpec<Changes> = {
   added: string,
   removed: string,
 };
@@ -381,7 +377,7 @@ export interface UpdatedBug {
   last_change_time: datetime;
   changes: Map<
     Omit<keyof UpdateBugContent, "id_or_alias" | "ids" | "alias">,
-    UpdatedBugChanges
+    Changes
   >;
 }
 
@@ -389,7 +385,7 @@ export const UpdatedBugSpec: ObjectSpec<UpdatedBug> = {
   id: int,
   alias: array(string),
   last_change_time: datetime,
-  changes: map(string, object(UpdatedBugChangesSpec)),
+  changes: map(string, object(ChangesSpec)),
 };
 
 export interface UpdatedBugTemplate {
@@ -399,3 +395,104 @@ export interface UpdatedBugTemplate {
 export const UpdatedBugTemplateSpec: ObjectSpec<UpdatedBugTemplate> = {
   bugs: array(object(UpdatedBugSpec)),
 };
+
+export interface Attachment {
+  data: Buffer;
+  size: int;
+  creation_time: datetime;
+  last_change_time: datetime;
+  id: int;
+  bug_id: int;
+  file_name: string;
+  summary: string;
+  content_type: string;
+  is_private: boolean;
+  is_obsolete: boolean;
+  is_patch: boolean;
+  creator: string;
+  flags: Flag[];
+}
+
+export const AttachmentSpec: ObjectSpec<Attachment> = {
+  data: base64,
+  size: int,
+  creation_time: datetime,
+  last_change_time: datetime,
+  id: int,
+  bug_id: int,
+  file_name: string,
+  summary: string,
+  content_type: string,
+  is_private: boolean,
+  is_obsolete: boolean,
+  is_patch: boolean,
+  creator: string,
+  flags: array(object(FlagSpec)),
+};
+
+export interface Attachments {
+  bugs: Map<number, Attachment[]>;
+  attachments: Map<number, Attachment>;
+}
+
+export const AttachmentsSpec: ObjectSpec<Attachments> = {
+  bugs: map(intString, array(object(AttachmentSpec))),
+  attachments: map(intString, object(AttachmentSpec)),
+};
+
+export interface CreateAttachmentContent {
+  ids: int[];
+  data: Buffer | ArrayBuffer;
+  file_name: string;
+  summary: string;
+  content_type: string;
+  comment?: string;
+  is_patch?: boolean;
+  is_private?: boolean;
+  flags?: SetFlag[];
+}
+
+export interface CreatedAttachment {
+  ids: int[];
+}
+
+export const CreatedAttachmentSpec: ObjectSpec<CreatedAttachment> = {
+  ids: array(int),
+};
+
+export interface UpdateAttachmentContent {
+  attachment_id?: int;
+  ids?: int[];
+  file_name?: string;
+  summary?: string;
+  comment?: string;
+  content_type?: string;
+  is_patch?: boolean;
+  is_private?: boolean;
+  is_obsolete?: boolean;
+  flags?: UpdateFlag[];
+}
+
+export interface UpdatedAttachment {
+  id: int;
+  last_change_time: datetime;
+  changes: Map<
+    Omit<keyof UpdateAttachmentContent, "attachment_id" | "ids">,
+    Changes
+  >;
+}
+
+export const UpdatedAttachmentSpec: ObjectSpec<UpdatedAttachment> = {
+  id: int,
+  last_change_time: datetime,
+  changes: map(string, object(ChangesSpec)),
+};
+
+export interface UpdatedAttachmentTemplate {
+  attachments: UpdatedAttachment[];
+}
+
+export const UpdatedAttachmentTemplateSpec: ObjectSpec<UpdatedAttachmentTemplate> =
+  {
+    attachments: array(object(UpdatedAttachmentSpec)),
+  };

--- a/src/validators.ts
+++ b/src/validators.ts
@@ -86,6 +86,22 @@ export const int = typedValidator<number>("number");
 export const double = typedValidator<number>("number");
 export const string = typedValidator<string>("string");
 
+export function base64(val: any): Buffer {
+  if (typeof val != "string") {
+    throw new Error(
+      `Expected a base64 encoded string but received ${repr(val)}`,
+    );
+  }
+
+  try {
+    return Buffer.from(val, "base64");
+  } catch (_) {
+    throw new Error(
+      `Expected a base64 encoded string but received ${repr(val)}`,
+    );
+  }
+}
+
 export function nullable<T>(validator: Validator<T>): Validator<T | null>;
 export function nullable<T>(validator: Validator<T>, result: T): Validator<T>;
 export function nullable<T>(

--- a/test/validators.test.ts
+++ b/test/validators.test.ts
@@ -14,6 +14,7 @@ import {
   intString,
   map,
   either,
+  base64,
 } from "../src/validators";
 
 // Force all times to UTC.
@@ -319,5 +320,27 @@ test("either", () => {
   );
   expect(() => either(string, int)({})).toThrowErrorMatchingInlineSnapshot(
     `"Expected an  or  but received \`{}\`"`,
+  );
+});
+
+test("base64", () => {
+  expect(base64("base64 string")).toEqual(
+    Buffer.from([109, 171, 30, 235, 139, 45, 174, 41, 224]),
+  );
+
+  expect(() => base64(null)).toThrowErrorMatchingInlineSnapshot(
+    `"Expected a base64 encoded string but received \`null\`"`,
+  );
+  expect(() => base64(undefined)).toThrowErrorMatchingInlineSnapshot(
+    `"Expected a base64 encoded string but received \`undefined\`"`,
+  );
+  expect(() => base64(0)).toThrowErrorMatchingInlineSnapshot(
+    `"Expected a base64 encoded string but received \`0\`"`,
+  );
+  expect(() => base64([])).toThrowErrorMatchingInlineSnapshot(
+    `"Expected a base64 encoded string but received \`[]\`"`,
+  );
+  expect(() => base64([""])).toThrowErrorMatchingInlineSnapshot(
+    `"Expected a base64 encoded string but received \`[\\"\\"]\`"`,
   );
 });


### PR DESCRIPTION
This PR is attempting to add support for:
- [x] Getting Attachments
- [x] Creating Attachments
- [x] Updating Attachments

Status:
- [x] Tested
- [x] Documented

---
PR also includes small bugfixes, documentation updates and refactoring.
Related to #40 