### PR TITLE
test: Extend integration test suite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Run tests against a live Bugzilla instance.
 - Added `getAttachment`, `getBugAttachments`, `createAttachment` and `updateAttachment` API methods.
+- Add integration tests for rest of API methods
 
 # [2.2.0](https://github.com/Mossop/bugzilla-ts/compare/v2.1.0...v2.2.0)
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ now.
 
 # Tests
 
-Some basic tests now exist. `npm test` will run the main tests. `npm itest` will run some
+Some basic tests now exist. `npm test` will run the main tests. `npm run itest` will run some
 integration tests against a real Bugzilla instance however you must have docker installed
 in order to run these.
 

--- a/itest/jest.config.js
+++ b/itest/jest.config.js
@@ -9,6 +9,8 @@ module.exports = {
   maxConcurrency: 1,
   maxWorkers: 1,
 
+  testTimeout: 10000,
+
   globalSetup: path.join(__dirname, "setup.js"),
   globalTeardown: path.join(__dirname, "teardown.js"),
   setupFilesAfterEnv: [path.join(__dirname, "testSetup.js")],

--- a/itest/test/bugs.test.ts
+++ b/itest/test/bugs.test.ts
@@ -1,28 +1,51 @@
 import BugzillaAPI from "../../src";
 
-test("Create bug", async () => {
-  let api = new BugzillaAPI(
+let api: BugzillaAPI;
+
+const bug = {
+  product: "TestProduct",
+  component: "TestComponent",
+  summary: "A test bug",
+  version: "unspecified",
+  description: "This is a test bug",
+  op_sys: "Mac OS",
+  platform: "Macintosh",
+  priority: "High",
+  severity: "major",
+};
+
+let bugs: number[] = [];
+
+beforeAll(async () => {
+  api = new BugzillaAPI(
     "http://localhost:8088/bugzilla/",
     "admin@nowhere.com",
     "adminpass",
   );
 
-  await expect(
-    api.createBug({
+  bugs.push(await api.createBug(bug));
+  bugs.push(await api.createBug(bug));
+  bugs.push(
+    await api.createBug({
       product: "TestProduct",
       component: "TestComponent",
-      summary: "A test bug",
+      summary: "A test bug 2",
       version: "unspecified",
-      description: "This is a test bug",
+      description: "This is a test bug 2",
       op_sys: "Mac OS",
       platform: "Macintosh",
       priority: "High",
-      severity: "major",
+      severity: "normal",
     }),
-  ).resolves.toBe(1);
+  );
 
-  let bugs = await api.getBugs([1]);
-  expect(bugs).toEqual([
+  expect(bugs).toBeDefined();
+  expect(bugs.length).toEqual(3);
+});
+
+test("Fetch bugs", async () => {
+  let result = await api.getBugs([bugs[0] as number, bugs[1] as number]);
+  expect(result).toEqual([
     {
       alias: [],
       assigned_to: "admin@nowhere.com",
@@ -47,7 +70,55 @@ test("Create bug", async () => {
       dupe_of: null,
       flags: [],
       groups: [],
-      id: 1,
+      id: bugs[0],
+      is_cc_accessible: true,
+      is_confirmed: true,
+      is_creator_accessible: true,
+      is_open: true,
+      keywords: [],
+      last_change_time: expect.anything(),
+      op_sys: "Mac OS",
+      platform: "Macintosh",
+      priority: "High",
+      product: "TestProduct",
+      qa_contact: "",
+      qa_contact_detail: undefined,
+      resolution: "",
+      see_also: [],
+      severity: "major",
+      status: "CONFIRMED",
+      summary: "A test bug",
+      target_milestone: "---",
+      update_token: undefined,
+      url: "",
+      version: "unspecified",
+      whiteboard: "",
+    },
+    {
+      alias: [],
+      assigned_to: "admin@nowhere.com",
+      assigned_to_detail: {
+        id: 1,
+        name: "admin@nowhere.com",
+        real_name: "Insecure User",
+      },
+      blocks: [],
+      cc: [],
+      cc_detail: [],
+      classification: "Unclassified",
+      component: "TestComponent",
+      creation_time: expect.anything(),
+      creator: "admin@nowhere.com",
+      creator_detail: {
+        id: 1,
+        name: "admin@nowhere.com",
+        real_name: "Insecure User",
+      },
+      depends_on: [],
+      dupe_of: null,
+      flags: [],
+      groups: [],
+      id: bugs[1],
       is_cc_accessible: true,
       is_confirmed: true,
       is_creator_accessible: true,
@@ -73,5 +144,183 @@ test("Create bug", async () => {
     },
   ]);
 
-  await expect(api.quicksearch("ALL")).resolves.toEqual(bugs);
+  await expect(api.quicksearch("ALL")).resolves.toEqual(
+    expect.arrayContaining(result),
+  );
+});
+
+test("Update bug", async () => {
+  await expect(
+    api.updateBug(bugs[0] as number, {
+      id_or_alias: bugs[0] as number,
+      ids: [bugs[0] as number],
+      blocks: { set: [bugs[1] as number] },
+      comment: { comment: "New comment", is_private: false },
+      severity: "normal",
+    }),
+  ).resolves.toEqual([
+    {
+      alias: [],
+      changes: new Map([
+        ["blocks", { added: "2", removed: "" }],
+        ["severity", { added: "normal", removed: "major" }],
+      ]),
+      id: bugs[0],
+      last_change_time: expect.anything(),
+    },
+  ]);
+});
+
+test("Update multiple bugs", async () => {
+  await expect(
+    api.updateBug(bugs[0] as number, {
+      id_or_alias: bugs[0] as number,
+      ids: [bugs[0] as number, bugs[1] as number],
+      severity: "major",
+    }),
+  ).resolves.toEqual([
+    {
+      alias: [],
+      changes: new Map([["severity", { added: "major", removed: "normal" }]]),
+      id: bugs[0],
+      last_change_time: expect.anything(),
+    },
+    {
+      alias: [],
+      changes: new Map(),
+      id: bugs[1],
+      last_change_time: expect.anything(),
+    },
+  ]);
+});
+
+test("Quickly search non-important bugs", async () => {
+  await expect(api.quicksearch("severity:normal")).resolves.toEqual([
+    {
+      alias: [],
+      assigned_to: "admin@nowhere.com",
+      assigned_to_detail: {
+        id: 1,
+        name: "admin@nowhere.com",
+        real_name: "Insecure User",
+      },
+      blocks: [],
+      cc: [],
+      cc_detail: [],
+      classification: "Unclassified",
+      component: "TestComponent",
+      creation_time: expect.anything(),
+      creator: "admin@nowhere.com",
+      creator_detail: {
+        id: 1,
+        name: "admin@nowhere.com",
+        real_name: "Insecure User",
+      },
+      depends_on: [],
+      dupe_of: null,
+      flags: [],
+      groups: [],
+      id: bugs[2],
+      is_cc_accessible: true,
+      is_confirmed: true,
+      is_creator_accessible: true,
+      is_open: true,
+      keywords: [],
+      last_change_time: expect.anything(),
+      op_sys: "Mac OS",
+      platform: "Macintosh",
+      priority: "High",
+      product: "TestProduct",
+      qa_contact: "",
+      qa_contact_detail: undefined,
+      resolution: "",
+      see_also: [],
+      severity: "normal",
+      status: "CONFIRMED",
+      summary: "A test bug 2",
+      target_milestone: "---",
+      update_token: undefined,
+      url: "",
+      version: "unspecified",
+      whiteboard: "",
+    },
+  ]);
+});
+
+test("Get history of bug", async () => {
+  await expect(api.bugHistory(bugs[2] as number)).resolves.toEqual([]);
+});
+
+test("Use of advance searching", async () => {
+  const expected = [
+    {
+      alias: [],
+      assigned_to: "admin@nowhere.com",
+      assigned_to_detail: {
+        id: 1,
+        name: "admin@nowhere.com",
+        real_name: "Insecure User",
+      },
+      blocks: [],
+      cc: [],
+      cc_detail: [],
+      classification: "Unclassified",
+      component: "TestComponent",
+      creation_time: expect.anything(),
+      creator: "admin@nowhere.com",
+      creator_detail: {
+        id: 1,
+        name: "admin@nowhere.com",
+        real_name: "Insecure User",
+      },
+      depends_on: [],
+      dupe_of: null,
+      flags: [],
+      groups: [],
+      id: bugs[2],
+      is_cc_accessible: true,
+      is_confirmed: true,
+      is_creator_accessible: true,
+      is_open: true,
+      keywords: [],
+      last_change_time: expect.anything(),
+      op_sys: "Mac OS",
+      platform: "Macintosh",
+      priority: "High",
+      product: "TestProduct",
+      qa_contact: "",
+      qa_contact_detail: undefined,
+      resolution: "",
+      see_also: [],
+      severity: "normal",
+      status: "CONFIRMED",
+      summary: "A test bug 2",
+      target_milestone: "---",
+      update_token: undefined,
+      url: "",
+      version: "unspecified",
+      whiteboard: "",
+    },
+  ];
+
+  await expect(
+    api.advancedSearch(
+      "http://localhost:8088/bugzilla/buglist.cgi?email1=admin%40nowhere.com&severity=normal",
+    ),
+  ).resolves.toEqual(expected);
+
+  await expect(
+    api.advancedSearch("email1=admin%40nowhere.com&severity=normal"),
+  ).resolves.toEqual(expected);
+
+  await expect(
+    api.advancedSearch({
+      email1: "admin@nowhere.com",
+      severity: "normal",
+    }),
+  ).resolves.toEqual(expected);
+});
+
+afterAll(() => {
+  bugs = [];
 });

--- a/itest/test/comments.test.ts
+++ b/itest/test/comments.test.ts
@@ -1,0 +1,87 @@
+import BugzillaAPI from "../../src";
+
+let api: BugzillaAPI;
+
+const bug = {
+  product: "TestProduct",
+  component: "TestComponent",
+  summary: "A test bug",
+  version: "unspecified",
+  description: "This is a test bug",
+  op_sys: "Mac OS",
+  platform: "Macintosh",
+  priority: "High",
+  severity: "major",
+};
+
+let bugs: number[] = [];
+
+beforeAll(async () => {
+  api = new BugzillaAPI(
+    "http://localhost:8088/bugzilla/",
+    "admin@nowhere.com",
+    "adminpass",
+  );
+
+  bugs.push(await api.createBug(bug));
+  bugs.push(await api.createBug(bug));
+
+  expect(bugs).toBeDefined();
+  expect(bugs.length).toEqual(2);
+});
+
+test("Create comment", async () => {
+  await expect(
+    api.createComment(bugs[0] as number, "First comment!", {
+      is_private: false,
+    }),
+  ).resolves.toEqual(3);
+});
+
+test("getComment", async () => {
+  await expect(api.getComment(3)).resolves.toEqual({
+    attachment_id: null,
+    bug_id: 1,
+    count: 1,
+    creation_time: expect.anything(),
+    creator: "admin@nowhere.com",
+    id: 3,
+    is_private: false,
+    tags: [],
+    text: "First comment!",
+    time: expect.anything(),
+  });
+});
+
+test("getBugComments", async () => {
+  await expect(api.getBugComments(bugs[0] as number)).resolves.toEqual([
+    {
+      attachment_id: null,
+      bug_id: bugs[0],
+      count: 0,
+      creation_time: expect.anything(),
+      creator: "admin@nowhere.com",
+      id: expect.anything(),
+      is_private: false,
+      tags: [],
+      text: "This is a test bug",
+      time: expect.anything(),
+    },
+    {
+      attachment_id: null,
+      bug_id: bugs[0],
+      count: 1,
+      creation_time: expect.anything(),
+      creator: "admin@nowhere.com",
+      id: expect.anything(),
+      is_private: false,
+      tags: [],
+      text: "First comment!",
+      time: expect.anything(),
+    },
+  ]);
+});
+
+afterAll(() => {
+  bugs = [];
+});

--- a/src/types.ts
+++ b/src/types.ts
@@ -318,7 +318,7 @@ export interface UpdateList<T> {
 export type UpdateOrReplaceList<T> =
   | UpdateList<T>
   | {
-      set: T[];
+      set?: T[];
     };
 
 export interface UpdateBugContent {


### PR DESCRIPTION
This PR extends a new integration test suite, to improve test coverage:
- [x] `createBug`, `updateBug`, `getBugs`, `quicksearch`, `bugHistory` and `advancedSearch`
- [x]  `createComment`, `getComment` and `getBugComments`