### PR TITLE
ci(lint): add shell linter - Differential ShellCheck

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,12 @@
 version: 2
+
 updates:
-  - package-ecosystem: "npm"
-    directory: "/"
+  - package-ecosystem: npm
+    directory: /
     schedule:
-      interval: "weekly"
+      interval: monthly
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly

--- a/.github/workflows/differential-shellcheck.yml
+++ b/.github/workflows/differential-shellcheck.yml
@@ -1,0 +1,26 @@
+name: Differential ShellCheck
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    permissions:
+      security-events: write
+      pull-requests: write
+
+    steps:
+      - name: Repository checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Differential ShellCheck
+        uses: redhat-plumbers-in-action/differential-shellcheck@latest
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Differential ShellCheck is a GitHub action that performs differential ShellCheck scans on shell scripts changed via PR and reports results directly in PR. The beauty of differential scans is that you will get reports only about newly added defects. 

Since this repository has few shell scripts, I think you might find some value in having a shell linter. Differential ShellCheck action is able to produce reports in SARIF format. GitHub understands this format and is able to display it nicely as a PR comment, and on the `Files Changed` tab, please see below.

![image](https://user-images.githubusercontent.com/2879818/183250924-b24fdcf1-c10c-4e7a-b4e5-76f25c1e06a0.png)

![image](https://user-images.githubusercontent.com/2879818/183250933-27cd182f-47f5-42fd-a2e6-1789bf5c3fc3.png)

Documentation is available at [@redhat-plumbers-in-action/differential-shellcheck](https://github.com/redhat-plumbers-in-action/differential-shellcheck#readme). Let me know If you are missing some feature or setting. I'm always happy to extend functionality.

> **Note**: _I have also added GitHub actions into Dependabot to keep your workflows up to date and changed the interval for Dependabot from weekly to monthly so it is less noisy_